### PR TITLE
Fix the links and the name

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,23 +1,23 @@
 {
-  "name": "hopr.public.dappnode.eth",
+  "name": "hopr.dnp.dappnode.eth",
   "version": "1.0.1",
   "upstreamVersion": "v1.90.26",
   "description": "The HOPR protocol ensures everyone has control of their privacy, data, and identity. By running a HOPR Node, you can obtain HOPR tokens by relaying data and connect to the HOPR Network.",
   "type": "service",
   "architectures": ["linux/amd64"],
+  "mainService": "node",
   "author": "HOPR Association <admin@hoprnet.org> (https://hoprnet.org)",
   "contributors": [
     "Tropicar <tropicar@protonmail.com> (https://github.com/tropicar)"
   ],
-  "mainService": "node",
   "upstreamRepo": "hoprnet/hoprnet",
   "upstreamArg": "UPSTREAM_VERSION",
   "categories": ["Communications", "Economic incentive"],
   "links": {
     "homepage": "https://hoprnet.org/",
-    "ui": "http://hopr.dappnode:3000?apiEndpoint=http://hopr.dappnode:3001&apiToken=!5qxc9Lp1BE7IFQ-nrtttU",
-    "api": "http://hopr.dappnode:3001",
-    "healthcheck": "http://hopr.dappnode:8080/healthcheck/v1/version",
+    "ui": "http://node.hopr.dappnode:3000/?apiEndpoint=http://node.hopr.dappnode:3001&apiToken=!5qxc9Lp1BE7IFQ-nrtttU",
+    "api": "http://node.hopr.dappnode:3001",
+    "healthcheck": "http://node.hopr.dappnode:8080/healthcheck/v1/version",
     "docs": "https://docs.hoprnet.org"
   },
   "repository": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   node:
-    image: "node.hopr.public.dappnode.eth:1.0.1"
+    image: "node.hopr.dnp.dappnode.eth:1.0.1"
     build:
       context: .
       args:
@@ -9,9 +9,7 @@ services:
     ports:
       - "9091:9091/tcp"
       - "9091:9091/udp"
-      - "3000:3000"
-      - "3001:3001"
-      - "8080:8080"
+      - "3001"
     volumes:
       - "db:/app/hoprd-db"
     environment:


### PR DESCRIPTION
For some reason, the dns does work correctly and it required to use of the prefix of the service don't the URL of the links
Some ports have been removed from the docker-compose because are not required. 
Change the name of the package to the official dnp instead of public.