### PR TITLE
Revert name to public

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hopr.dnp.dappnode.eth",
+  "name": "hopr.public.dappnode.eth",
   "version": "1.0.1",
   "upstreamVersion": "v1.90.26",
   "description": "The HOPR protocol ensures everyone has control of their privacy, data, and identity. By running a HOPR Node, you can obtain HOPR tokens by relaying data and connect to the HOPR Network.",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   node:
-    image: "node.hopr.dnp.dappnode.eth:1.0.1"
+    image: "node.hopr.public.dappnode.eth:1.0.1"
     build:
       context: .
       args:


### PR DESCRIPTION
The package will be maintained for hopr team, it does not make sense to have the dnp in the name