### PR TITLE
Update to final version of release Valencia

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "hopr.public.dappnode.eth",
-  "version": "1.0.1",
-  "upstreamVersion": "v1.90.40",
+  "version": "1.0.2",
+  "upstreamVersion": "v1.90.63",
   "description": "The HOPR protocol ensures everyone has control of their privacy, data, and identity. By running a HOPR Node, you can obtain HOPR tokens by relaying data and connect to the HOPR Network.",
   "type": "service",
   "architectures": ["linux/amd64"],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: "3.5"
 services:
   node:
-    image: "node.hopr.public.dappnode.eth:1.0.1"
+    image: "node.hopr.public.dappnode.eth:1.0.2"
     build:
       context: .
       args:
-        UPSTREAM_VERSION: 1.90.40
+        UPSTREAM_VERSION: 1.90.63
     ports:
       - "9091:9091/tcp"
       - "9091:9091/udp"
@@ -37,6 +37,6 @@ services:
     deploy:
       resources:
         limits:
-          memory: 1G
+          memory: 2G
 volumes:
   db: {}

--- a/getstarted.md
+++ b/getstarted.md
@@ -1,0 +1,17 @@
+## What is HOPR?
+
+HOPR keeps any exchange of data private. Standard end-to-end encryption does not provide sufficient privacy. It leaks important metadata, such as who is exchanging data, when, and how often. Securing network-level privacy with HOPR unlocks a range of opportunities
+
+## Who should be interested
+
+Anyone interested in privacy and earning cryptocurrencies for running a node
+
+## More Information
+
+[https://hoprnet.org/](https://hoprnet.org/)
+Telegram: [https://t.me/hoprnet](https://hoprnet.org/)
+
+## Getting Started
+
+To install HOPR follow the instructions at [docs.hoprnet.org/node/using-dappnode](https://docs.hoprnet.org/node/using-dappnode) 
+


### PR DESCRIPTION
- bump upstream version to 1.90.63 (final Valencia release)
- update the docs
- bump memory limit to 2 GB