### PR TITLE
Additional hotfix for the Valencia release

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,20 @@
+# Repository structure
+
+
+There are two repositories:
+
+- official: https://github.com/dappnode/DAppNodePackage-Hopr
+- internal: https://github.com/hoprnet/DAppNodePackage-Hopr
+
+The `internal` is a fork of the `official` one. 
+
+Tha development happens on the internal repository and it has two branches:
+
+- `develop` which contains the edge version, not meant for publishing
+- `main` which is supposed to be in-sync with the `main` branch on the `official` repo
+
+
+PRs are only meant to be made from the `internal` repo's `main` branch to the `official` repo's `main` branch.
+
+
+

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "hopr.public.dappnode.eth",
-  "version": "1.0.2",
-  "upstreamVersion": "v1.90.63",
+  "version": "1.0.3",
+  "upstreamVersion": "v1.90.68",
   "description": "The HOPR protocol ensures everyone has control of their privacy, data, and identity. By running a HOPR Node, you can obtain HOPR tokens by relaying data and connect to the HOPR Network.",
   "type": "service",
   "architectures": ["linux/amd64"],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: "3.5"
 services:
   node:
-    image: "node.hopr.public.dappnode.eth:1.0.2"
+    image: "node.hopr.public.dappnode.eth:1.0.3"
     build:
       context: .
       args:
-        UPSTREAM_VERSION: 1.90.63
+        UPSTREAM_VERSION: 1.90.68
     ports:
       - "9091:9091/tcp"
       - "9091:9091/udp"


### PR DESCRIPTION
One additional hotfix needed for the Valencia release.

Version bump to 1.0.3 (upstream 1.90.68).