### PR TITLE
Make configuration file configurable

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -56,7 +56,7 @@
   "backup": [
     {
       "name": "db",
-      "path": "/app/hoprd-db/db"
+      "path": "/app/hoprd-db/sqlite"
     },
     {
       "name": "identity",

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -56,11 +56,15 @@
   "backup": [
     {
       "name": "db",
-      "path": "/app/hoprd-db/data"
+      "path": "/app/hoprd-db/db"
     },
     {
       "name": "identity",
       "path": "/app/hoprd-db/.hopr-identity"
+    },
+    {
+      "name": "config",
+      "path": "/app/hoprd.cfg.yaml"
     }
   ],
   "globalEnvs": [

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -56,7 +56,7 @@
   "backup": [
     {
       "name": "db",
-      "path": "/app/hoprd-db/sqlite"
+      "path": "/app/hoprd-db/db"
     },
     {
       "name": "identity",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,10 +11,11 @@ services:
       - "9091:9091/udp"
       - "3001"
     volumes:
-      - "data:/app/data"
+      - "data:/app/hoprd-db"
     environment:
       - RUST_LOG=info
       - HOPRD_NETWORK=dufour
+      - HOPRD_CONFIGURATION_FILE_PATH=/app/hoprd.cfg.yaml
       - HOPRD_HOST=127.0.0.1:9091
       - HOPRD_SAFE_ADDRESS=0x
       - HOPRD_MODULE_ADDRESS=0x

--- a/hoprd.cfg.yaml
+++ b/hoprd.cfg.yaml
@@ -2,14 +2,21 @@
 
 hopr:
   db:
-    data: /app/hoprd-db/db
+    data: /app/hoprd-db/sqlite
     initialize: true
     force_initialize: false
   strategy:
     on_fail_continue: true
     allow_recursive: true
     finalize_channel_closure: true
-    strategies: []
+    strategies:
+      - !Aggregating
+        aggregation_threshold: 300
+        unrealized_balance_ratio: 0.9
+        aggregation_timeout: 60
+        aggregate_on_channel_close: true
+      - !AutoRedeeming
+        redeem_only_aggregated: true
   network_options:
     min_delay: 1
     max_delay: 300

--- a/hoprd.cfg.yaml
+++ b/hoprd.cfg.yaml
@@ -2,7 +2,7 @@
 
 hopr:
   db:
-    data: /app/hoprd-db/sqlite
+    data: /app/hoprd-db/db
     initialize: true
     force_initialize: false
   strategy:

--- a/hoprd.cfg.yaml
+++ b/hoprd.cfg.yaml
@@ -2,7 +2,7 @@
 
 hopr:
   db:
-    data: /app/data/db
+    data: /app/hoprd-db/db
     initialize: true
     force_initialize: false
   strategy:
@@ -39,7 +39,7 @@ hopr:
     announce_local_addresses: false
     prefer_local_addresses: false
 identity:
-  file: '/app/data/hoprd.id'
+  file: /app/hoprd-db/.hopr-identity
 api:
   enable: true
   host:

--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -57,6 +57,16 @@ fields:
     description: Upload custom identity file of a previously deployed HOPR node.
     secret: false
 
+  - id: CONFIG
+    target:
+      type: fileUpload
+      path: /app/hoprd.cfg.yaml
+      service: node
+    title: Custom HOPR node configuration file
+    required: false
+    description: Upload custom configuration file for the HOPR node.
+    secret: false
+
   - id: HOPRD_SAFE_ADDRESS
     target:
       type: environment


### PR DESCRIPTION
- makes the node use the configuration file in addition to env variables
- makes it possible to backup the configuration file
- adds aggregating and autoredeeming as default strategies