### PR TITLE
Use same volume name as before the recent changes.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,4 +43,4 @@ services:
         limits:
           memory: 256M
 volumes:
-  data: {}
+  db: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "9091:9091/udp"
       - "3001"
     volumes:
-      - "data:/app/hoprd-db"
+      - "db:/app/hoprd-db"
     security_opt:
       - "seccomp:unconfined"
     environment:


### PR DESCRIPTION
If the volume name differs, the identity files are re-created.