### PR TITLE
Allow port range for p2p port configuration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    depends-on: build-test
+    needs: build-test
     steps:
       - uses: actions/checkout@v2
       - name: Publish

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,10 +2,6 @@ name: "Main"
 on:
   pull_request:
   push:
-    branches:
-      - "master"
-      - "main"
-      - "v[0-9]+.[0-9]+.[0-9]+"
     paths-ignore:
       - "README.md"
 
@@ -13,7 +9,6 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     name: Build test
-    if: github.event_name != 'push'
     steps:
       - uses: actions/checkout@v2
       - run: npx @dappnode/dappnodesdk build --skip_save
@@ -21,7 +16,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    depends-on: build-test
     steps:
       - uses: actions/checkout@v2
       - name: Publish

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -36,11 +36,6 @@
   },
   "exposable": [
     {
-      "name": "HOPR",
-      "description": "HOPR P2P port",
-      "port": 9091
-    },
-    {
       "name": "HOPR Admin UI",
       "description": "Port for HOPR Admin UI console",
       "port": 3000
@@ -49,6 +44,51 @@
       "name": "HOPR REST API",
       "description": "Port for HOPR node REST API",
       "port": 3001
+    },
+    {
+      "name": "HOPR p2p",
+      "description": "HOPR P2P port",
+      "port": 9091
+    },
+    {
+      "name": "HOPR p2p (alt 1)",
+      "description": "HOPR P2P port (alternative 1)",
+      "port": 9092
+    },
+    {
+      "name": "HOPR p2p (alt 2)",
+      "description": "HOPR P2P port (alternative 2)",
+      "port": 9093
+    },
+    {
+      "name": "HOPR p2p (alt 3)",
+      "description": "HOPR P2P port (alternative 3)",
+      "port": 9094
+    },
+    {
+      "name": "HOPR p2p (alt 4)",
+      "description": "HOPR P2P port (alternative 4)",
+      "port": 9095
+    },
+    {
+      "name": "HOPR p2p (alt 5)",
+      "description": "HOPR P2P port (alternative 5)",
+      "port": 9096
+    },
+    {
+      "name": "HOPR p2p (alt 6)",
+      "description": "HOPR P2P port (alternative 6)",
+      "port": 9097
+    },
+    {
+      "name": "HOPR p2p (alt 7)",
+      "description": "HOPR P2P port (alternative 7)",
+      "port": 9098
+    },
+    {
+      "name": "HOPR p2p (alt 8)",
+      "description": "HOPR P2P port (alternative 8)",
+      "port": 9099
     }
   ],
   "license": "GLP-3.0",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,8 @@ services:
         UPSTREAM_VERSION: >-
           2.1.0-rc.3@sha256:7b412b1bad4330b4ce87195cfa9ba84d852f105ba64fe30334df325317d99aee
     ports:
-      - "9091:9091/tcp"
-      - "9091:9091/udp"
+      - "9091-9099:9091-9099/tcp"
+      - "9091-9099:9091-9099/udp"
       - "3001"
     volumes:
       - "db:/app/hoprd-db"

--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -37,7 +37,7 @@ fields:
     description: |-
       URL to the custom RPC provider this HOPR node should use.
       If your DAppnode is running a Gnosis Chain RPC endpoint, it is **strongly recommended** to use it here.
-      
+
       *Example:* `http://nethermind-xdai.dappnode:8545`
     secret: false
     pattern: "^http[s]{0,1}://[a-z0-9.-]{3,}(:[0-9]{2,5})?(/[a-z0-9.-/_]+)?$"
@@ -84,7 +84,7 @@ fields:
       Ethereum address of the associated staking safe.
 
       Check [Staking Hub](https://hub.hoprnet.org/staking/dashboard) for the right address.
-      
+
       *Example:* `0x010203040506070809aabbccddeeff00112233`
     secret: false
     pattern: "^0x[a-fA-F0-9]{40}$"
@@ -101,7 +101,7 @@ fields:
       Ethereum address of the module connected to the associated staking safe.
 
       Check [Staking Hub](https://hub.hoprnet.org/staking/dashboard) for the right address.
-      
+
       *Example:* `0x010203040506070809aabbccddeeff00112233`
     secret: false
     pattern: "^0x[a-fA-F0-9]{40}$"
@@ -119,14 +119,13 @@ fields:
       on your router and exposed to the Internet.
       You can also use the (dyn)DNS name of your node as `host`.
       The `host` part must be an external public IP address or DNS name of this node.
-      The recommended default TCP `port` is 9091.
+      The recommended default TCP `port` is 9091, but any port in the range 9091-9099 is usable.
 
       *Make sure the given port is port-forwarded on your router and exposed to the Internet.*
-      
+
       *Example (public IP address):* `1.2.3.4:9091`
 
       *Example (dynDNS entry):* `abcd1234.dyndns.dappnode.io:9091`
     secret: false
     pattern: "^[a-z0-9.-]{3,}:[0-9]{2,5}$"
     patternErrorMessage: Must be in correct host:port format!
-

--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -127,5 +127,5 @@ fields:
 
       *Example (dynDNS entry):* `abcd1234.dyndns.dappnode.io:9091`
     secret: false
-    pattern: "^[a-z0-9.-]{3,}:[0-9]{2,5}$"
+    pattern: "^[a-z0-9.-]{3,}:909[1-9]$"
     patternErrorMessage: Must be in correct host:port format!


### PR DESCRIPTION
- Allow port range 9091-9099 to be used for p2p port instead of 9091 only
- Run release workflow on every PR