### PR TITLE
Change location of the ID file

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -110,7 +110,7 @@
     },
     {
       "name": "identity",
-      "path": "/app/hoprd-db/.hopr-identity"
+      "path": "/app/hopr.id"
     },
     {
       "name": "config",

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -106,7 +106,7 @@
   "backup": [
     {
       "name": "db",
-      "path": "/app/hoprd-db/db"
+      "path": "/app/hoprd-db"
     },
     {
       "name": "identity",

--- a/hoprd.cfg.yaml
+++ b/hoprd.cfg.yaml
@@ -47,7 +47,7 @@ hopr:
     announce_local_addresses: false
     prefer_local_addresses: false
 identity:
-  file: /app/hoprd-db/.hopr-identity
+  file: /app/hopr.id
 api:
   enable: true
   host:

--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -56,7 +56,7 @@ fields:
   - id: IDENTITY
     target:
       type: fileUpload
-      path: /app/hoprd-db/.hopr-identity
+      path: /app/hopr.id
       service: node
     title: Custom identity file
     required: false


### PR DESCRIPTION
Change the location of the Identity file.

Please note, that after upgrading to this node version, the identity file needs to be re-uploaded.
They can be still backed up after the update from the `db` backup.