### PR TITLE
Make target allowlist empty per default

### DIFF
--- a/hoprd.cfg.yaml
+++ b/hoprd.cfg.yaml
@@ -39,3 +39,6 @@ api:
   host:
     address: !IPv4 0.0.0.0
     port: 3001
+session_ip_forwarding:
+  target_allow_list: []
+


### PR DESCRIPTION
As in title.

This disables the Exit node functionality on Dappnode per default.