### PR TITLE
Improve wording for the setup wizard

### DIFF
--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -148,9 +148,8 @@ fields:
     title: Enable NAT mode
     required: false
     description: |-
-      By default the HOPR node assumes that it is running behind a NAT on a
-      dappnode. If this is not the case or proper port forwarding has been
-      set up this option can be set to `false` to disable NAT mode.
+      By default the HOPR node assumes that it is running behind a NAT when run on a dappnode.
+      If the dappnode is however publicly exposed, this option can be set to false.
     secret: false
     pattern: ^(true|false)$
     patternErrorMessage: Must be either `true` or `false`!


### PR DESCRIPTION
This pull request updates the description of the "Enable NAT mode" field in the `setup-wizard.yml` file to clarify the conditions under which NAT mode can be disabled.

* [`setup-wizard.yml`](diffhunk://#diff-2db96a5e3c93e12f1ad5762baa5b09d890bf284978dccd6fe2e61f347d7ee4e6L151-R152): Revised the description to specify that NAT mode can be disabled if the dappnode is publicly exposed, improving clarity and accuracy.